### PR TITLE
ALF-9 Frontend Scaffold and initial implementation 

### DIFF
--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -1,5 +1,5 @@
 pycodestyle==2.7.0
-mypy==0.971
+mypy==0.991
 mypy-extensions==0.4.3
 typing_extensions==4.3.0
 typed-ast==1.5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ requests==2.28.1
 PyJWT==2.3.0
 # Frontend
 streamlit==1.12.2
+streamlit-chat==0.0.2.2
 # Backend
 Flask==2.0.1
 waitress==2.0.0

--- a/src/alfred/cli.py
+++ b/src/alfred/cli.py
@@ -93,7 +93,7 @@ class CLI:
                 textwrap.dedent(
                     f"""
                     from alfred.frontend.controller import ViewController
-                    
+
                     if __name__ == "__main__":
                         controller = ViewController.instance()
                         controller.run(view_name={repr(view)})

--- a/src/alfred/frontend/__init__.py
+++ b/src/alfred/frontend/__init__.py
@@ -1,0 +1,12 @@
+import sys
+from typing import Optional
+
+
+def runner(temp_file: str, port: Optional[str] = None):
+    import importlib
+
+    # Start streaming application
+    port = port or "8501"
+    streamlit_cli = importlib.import_module("streamlit.web.cli")
+    sys.argv = ["streamlit", "run", temp_file, "--server.port", port]
+    streamlit_cli.main()

--- a/src/alfred/frontend/controller.py
+++ b/src/alfred/frontend/controller.py
@@ -6,7 +6,7 @@ from alfred.utils.string_ops import camel_to_snake
 
 
 class ViewController:
-    views: Dict[str, Callable]
+    views: Dict[str, ViewInterface]
     _created_at: dt.datetime
     _instance = None
 

--- a/src/alfred/frontend/controller.py
+++ b/src/alfred/frontend/controller.py
@@ -1,0 +1,70 @@
+import datetime as dt
+from typing import Dict, Optional, Callable
+
+from alfred.frontend.interface import ViewInterface
+from alfred.utils.string_ops import camel_to_snake
+
+
+class ViewController:
+    views: Dict[str, Callable]
+    _created_at: dt.datetime
+    _instance = None
+
+    def __init__(self):
+        raise ValueError("Call the 'instance' method instead.")
+
+    def __new__(cls, *args, **kwargs):
+        import pkgutil
+        import inspect
+        import importlib
+
+        module = importlib.import_module("alfred.frontend.views")  # Import current module
+        cls.views: Dict[str, ViewInterface] = {
+            camel_to_snake(cls_name): cls_ref
+            for submodule_info in pkgutil.iter_modules(module.__path__)
+            for cls_name, cls_ref in inspect.getmembers(
+                importlib.import_module(".".join([module.__name__, submodule_info.name])),
+                inspect.isclass
+            )
+            if issubclass(cls_ref, ViewInterface) and cls_ref != ViewInterface
+        }
+        cls._created_at = dt.datetime.utcnow()
+        return super().__new__(cls)
+
+    @classmethod
+    def instance(cls):
+        if not cls._instance:
+            cls._instance = cls.__new__(cls)
+        return cls._instance
+
+    def run(self, view_name: Optional[str] = None,  **kwargs):
+        import streamlit as st
+
+        # Query params
+        query_params = st.experimental_get_query_params()
+
+        # Default values
+        view_name, *_ = query_params.get("view", [view_name or "about"])
+        views = {
+            view_name: view_ref.instance()
+            for view_name, view_ref in self.views.items()
+        }
+
+        # Define the sidebar
+        view_selection, _ = st.sidebar.radio(
+            key="views_sidebar",
+            label="Alfred Options",
+            options=sorted(
+                [
+                    (view_name, view_instance.order_reference)
+                    for view_name, view_instance in views.items()
+                ],
+                key=lambda view_info: view_info[-1],
+                reverse=False,
+            ),
+            format_func=lambda view_info: views[view_info[0]].alias,
+        )
+
+        # Update query params to the corresponding value
+        st.experimental_set_query_params(view=view_selection)
+        views[view_selection].run(**kwargs)

--- a/src/alfred/frontend/functions.py
+++ b/src/alfred/frontend/functions.py
@@ -1,0 +1,42 @@
+from typing import Dict, Optional
+
+import streamlit as st
+
+from alfred.models.user import User
+
+
+def get_session_payload(token: str, disable_expiration: bool = False) -> Dict:
+    from alfred.utils.json_web_token import JsonWebToken
+
+    jwt = JsonWebToken.auto_configure(verify_exp=not disable_expiration)
+    return jwt.decode(token)
+
+
+def get_user(
+        disable_token_expiration: bool = False,
+) -> Optional[User]:
+    token = st.session_state.get("token")
+    if not token:
+        return
+    payload = get_session_payload(
+        token=token,
+        disable_expiration=disable_token_expiration
+    )
+    return User.get(email=payload["user"])
+
+
+def get_user_with_warning(
+        disable_token_expiration: bool = False,
+        disable_message: bool = False,
+        message: Optional[str] = None,
+) -> Optional[User]:
+    user = get_user(disable_token_expiration=disable_token_expiration)
+    if not user:
+        if not disable_message:
+            st.error(
+                message or (
+                    "You must have an active session to visualize this content."
+                )
+            )
+        return
+    return user

--- a/src/alfred/frontend/functions.py
+++ b/src/alfred/frontend/functions.py
@@ -17,7 +17,7 @@ def get_user(
 ) -> Optional[User]:
     token = st.session_state.get("token")
     if not token:
-        return
+        return None
     payload = get_session_payload(
         token=token,
         disable_expiration=disable_token_expiration
@@ -38,5 +38,5 @@ def get_user_with_warning(
                     "You must have an active session to visualize this content."
                 )
             )
-        return
+        return None
     return user

--- a/src/alfred/frontend/interface.py
+++ b/src/alfred/frontend/interface.py
@@ -1,0 +1,35 @@
+import datetime as dt
+from typing import Optional
+
+from alfred.models.user import User
+from alfred.frontend.functions import get_user_with_warning
+from alfred.utils.string_ops import camel_to_snake
+
+
+class ViewInterface:
+    order_reference: int
+    _instance = None
+
+    def __init__(self):
+        raise ValueError
+
+    def __new__(cls, *args, **kwargs):
+        cls.view_timestamp = dt.datetime.utcnow().isoformat()
+        return super().__new__(cls)
+
+    @classmethod
+    def instance(cls):
+        if not cls._instance:
+            cls._instance = cls.__new__(cls)
+        return cls._instance
+
+    @property
+    def alias(self) -> str:
+        return camel_to_snake(self.__name__)
+
+    @property
+    def user(self) -> Optional[User]:
+        return get_user_with_warning()
+
+    def run(self):
+        raise NotImplementedError

--- a/src/alfred/frontend/interface.py
+++ b/src/alfred/frontend/interface.py
@@ -25,7 +25,13 @@ class ViewInterface:
 
     @property
     def alias(self) -> str:
-        return camel_to_snake(self.__name__)
+        name = getattr(self, "__name__")  # Why not self.__name__? Because mypy...
+        # References:
+        # - https://github.com/python/cpython/issues/88690
+        # - https://github.com/python/mypy/issues/10403
+        # - https://github.com/python/mypy/issues/12795
+        # - https://docs.python.org/3/library/stdtypes.html#definition.__name__
+        return camel_to_snake(name)
 
     @property
     def user(self) -> Optional[User]:

--- a/src/alfred/frontend/views/about.py
+++ b/src/alfred/frontend/views/about.py
@@ -26,12 +26,12 @@ class About(ViewInterface):
         st.markdown(
             textwrap.dedent(
                 """
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi eu ultricies purus. Cras quis lacus turpis.
-                Nam sit amet aliquet mi. Duis lacinia, justo in faucibus tristique, leo dui tempus mauris,
-                eget aliquam mauris erat ac leo. Nam urna odio, scelerisque et nisi sit amet, ornare condimentum mauris.
-                Maecenas pellentesque, erat non pellentesque tincidunt, augue tortor sollicitudin libero,
-                eu vestibulum est risus in elit. Pellentesque in bibendum nisi, quis ornare diam.
-                Phasellus consectetur scelerisque libero, vel condimentum nulla consectetur sed.
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi eu ultricies purus.
+                Cras quis lacus turpis. Nam sit amet aliquet mi. Duis lacinia, justo in faucibus tristique,
+                leo dui tempus mauris, eget aliquam mauris erat ac leo. Nam urna odio, scelerisque et nisi sit amet,
+                ornare condimentum mauris. Maecenas pellentesque, erat non pellentesque tincidunt,
+                augue tortor sollicitudin libero, eu vestibulum est risus in elit. Pellentesque in bibendum nisi,
+                quis ornare diam. Phasellus consectetur scelerisque libero, vel condimentum nulla consectetur sed.
                 Proin vulputate nunc ut venenatis tempor. Duis pretium scelerisque eros vel euismod.
                 Quisque iaculis cursus sapien, at rutrum dolor egestas tempus.
                 Sed nec sapien id diam porttitor imperdiet et auctor lorem.

--- a/src/alfred/frontend/views/about.py
+++ b/src/alfred/frontend/views/about.py
@@ -1,0 +1,51 @@
+import textwrap
+from typing import Optional
+
+import streamlit as st
+
+from alfred.models.user import User
+from alfred.frontend.functions import get_user
+from alfred.frontend.interface import ViewInterface
+
+
+class About(ViewInterface):
+    order_reference = 0
+
+    @property
+    def alias(self) -> str:
+        return "About Alfred"
+
+    @property
+    def user(self) -> Optional[User]:
+        return get_user()
+
+    def run(self):
+        st.title("Introducing Alfred")
+        st.subheader("Your personal intelligent assistant.")
+
+        st.markdown(
+            textwrap.dedent(
+                """
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi eu ultricies purus. Cras quis lacus turpis.
+                Nam sit amet aliquet mi. Duis lacinia, justo in faucibus tristique, leo dui tempus mauris,
+                eget aliquam mauris erat ac leo. Nam urna odio, scelerisque et nisi sit amet, ornare condimentum mauris.
+                Maecenas pellentesque, erat non pellentesque tincidunt, augue tortor sollicitudin libero,
+                eu vestibulum est risus in elit. Pellentesque in bibendum nisi, quis ornare diam.
+                Phasellus consectetur scelerisque libero, vel condimentum nulla consectetur sed.
+                Proin vulputate nunc ut venenatis tempor. Duis pretium scelerisque eros vel euismod.
+                Quisque iaculis cursus sapien, at rutrum dolor egestas tempus.
+                Sed nec sapien id diam porttitor imperdiet et auctor lorem.
+                Ut id posuere metus. Etiam molestie ultricies sem, sit amet fringilla arcu ornare at.
+                Phasellus ac libero ornare, finibus diam et, mattis nunc.
+                """
+            )
+        )
+
+        if not self.user:
+            return st.info("You don't have any active sessions.")
+
+        st.success(f"Welcome {self.user.name}, you have an active session.")
+
+        if st.button(label="Logout"):
+            del st.session_state["token"]
+            st.experimental_rerun()

--- a/src/alfred/frontend/views/start_session.py
+++ b/src/alfred/frontend/views/start_session.py
@@ -1,0 +1,41 @@
+import time
+import datetime as dt
+
+import streamlit as st
+
+from alfred.models.user import User
+from alfred.utils.pwd import password_hash
+from alfred.utils.json_web_token import JsonWebToken
+from alfred.frontend.interface import ViewInterface
+from alfred.settings import get_logger
+
+logger = get_logger(name=__name__)
+
+class StartSession(ViewInterface):
+    order_reference = 1
+
+    @property
+    def alias(self) -> str:
+        return "Start Session"
+
+    def run(self):
+        with st.form("session"):
+            user_email = st.text_input(label="Email")
+            user_pwd = st.text_input(label="Password", type="password")
+            submitted = st.form_submit_button("Create")
+
+        if not submitted:
+            return
+
+        try:
+            user = User.get(email=user_email)
+            pwd_hash = password_hash(pwd=user_pwd, salt=user.password_salt)
+            if user.password_hash != pwd_hash:
+                raise ValueError
+        except Exception as e:
+            logger.error(e)
+            return st.error("User email or pwd is wrong.")
+
+        jwt = JsonWebToken.auto_configure(verify_exp=True)
+        st.session_state["token"] = jwt.encode(payload=user.session())
+        st.success(f"Welcome {user.name}!")

--- a/src/alfred/frontend/views/start_session.py
+++ b/src/alfred/frontend/views/start_session.py
@@ -11,6 +11,7 @@ from alfred.settings import get_logger
 
 logger = get_logger(name=__name__)
 
+
 class StartSession(ViewInterface):
     order_reference = 1
 

--- a/src/alfred/models/user.py
+++ b/src/alfred/models/user.py
@@ -1,3 +1,6 @@
+import datetime as dt
+from typing import Dict
+
 import peewee
 
 from alfred.dao.interface import BaseModel
@@ -53,3 +56,9 @@ class User(BaseModel):
                 password_salt=pwd_salt,
                 verified=False,
             )
+
+    def session(self) -> Dict:
+        return {
+            "user": self.email,
+            "auth_timestamp": dt.datetime.utcnow().isoformat(),
+        }

--- a/src/alfred/settings.py
+++ b/src/alfred/settings.py
@@ -2,11 +2,25 @@ import os
 import logging
 from typing import List, Optional
 
+# Logging
 
 ALFRED_LOG_LEVEL = os.environ.get(
     "ALFRED_LOG_LEVEL",
     default="INFO",
 ).strip()
+
+# Logging
+
+def get_logger(name: str, level: Optional[str] = None):
+    logging.basicConfig(
+        level=level or ALFRED_LOG_LEVEL
+    )
+    logger = logging.getLogger(name=name)
+    return logger
+
+
+_logger = get_logger(name=__name__)
+
 
 ALFRED_ACTIVATION_CODES: List[str] = os.environ.get(
     "ALFRED_ACTIVATION_CODES",
@@ -29,16 +43,17 @@ ALFRED_DEFAULT_SQLITE = os.environ.get(
     default="alfred.db"
 )
 
+# JWT Configs
 
-def get_logger(name: str, level: Optional[str] = None):
-    logging.basicConfig(
-        level=level or ALFRED_LOG_LEVEL
-    )
-    logger = logging.getLogger(name=name)
-    return logger
+ALFRED_JWT_ENCRYPTION_ALGO: str = os.environ.get(
+    "ALFRED_JWT_ENCRYPTION_ALGO",
+    default="HS256"
+)
 
-
-_logger = get_logger(name=__name__)
+def get_jwt_secret_key() -> str:
+    return os.environ.get("JWT_SECRET_KEY") or (
+        lambda : _logger.warning("Using the default JWT Secret Key") or "default"
+    )()
 
 
 if not ALFRED_SECRET:

--- a/src/alfred/settings.py
+++ b/src/alfred/settings.py
@@ -11,6 +11,7 @@ ALFRED_LOG_LEVEL = os.environ.get(
 
 # Logging
 
+
 def get_logger(name: str, level: Optional[str] = None):
     logging.basicConfig(
         level=level or ALFRED_LOG_LEVEL
@@ -50,9 +51,10 @@ ALFRED_JWT_ENCRYPTION_ALGO: str = os.environ.get(
     default="HS256"
 )
 
+
 def get_jwt_secret_key() -> str:
     return os.environ.get("JWT_SECRET_KEY") or (
-        lambda : _logger.warning("Using the default JWT Secret Key") or "default"
+        lambda: _logger.warning("Using the default JWT Secret Key") or "default"
     )()
 
 

--- a/src/alfred/utils/json_web_token.py
+++ b/src/alfred/utils/json_web_token.py
@@ -1,0 +1,46 @@
+from typing import Any, Dict, Optional
+
+from alfred.settings import (
+    ALFRED_JWT_ENCRYPTION_ALGO,
+    get_jwt_secret_key
+)
+
+
+class JsonWebToken:
+
+    def __init__(
+            self,
+            secret_key: str,
+            algorithm: Optional[str] = None,
+            verify_exp: bool = False,
+    ):
+        self._secret_key = secret_key
+        self.verify_exp = verify_exp
+        self.algorithm: str = algorithm or ALFRED_JWT_ENCRYPTION_ALGO
+
+    @classmethod
+    def auto_configure(cls, verify_exp: bool = False) -> 'JsonWebToken':
+        return cls(
+            secret_key=get_jwt_secret_key(),
+            algorithm=ALFRED_JWT_ENCRYPTION_ALGO,
+            verify_exp=verify_exp
+        )
+
+    def encode(self, payload: Dict) -> str:
+        import jwt  # type: ignore  # Lazy import
+        return jwt.encode(
+            payload,
+            key=self._secret_key,
+            algorithm=self.algorithm
+        )
+
+    def decode(self, string: str) -> Dict[str, Any]:
+        import jwt  # type: ignore  # Lazy import
+        return jwt.decode(
+            jwt=string,
+            key=self._secret_key,
+            algorithms=[self.algorithm],
+            options={
+                "verify_exp": self.verify_exp
+            }
+        )


### PR DESCRIPTION
This PR contains the scaffold infrastructure to allow having a simple frontend via `streamlit` and `streamlit-chat`.
* Closes #9 

The idea is simple:
* All the views are contained here `alfred.frontend.views` as independent submodules (one per view).
* Each submodule should implement from the `ViewInterface`.
* The `ViewController` contains the gateway for execution and implements the switching capability to change from one view to the other.

Check it out by running:

```commandline
$ alfred frontend
```

Currently, there are only a couple of views implemented: `about`, `session_start`

If you want to test this implementation (login as a user) you must create a user in the database. At the moment, you can use an interactive environment such as `ipython` or `jupyter` to create the user via our data models.